### PR TITLE
Feature/testspace with secret

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
         name: Push result to Testspace server 
         id: push_to_testspace
         run: | 
-          testspace __test/results.xml  
+          testspace "__test/results.xml{Source/Bogus.Tests}"  
 
       - if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         name: Upload package artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,8 @@ jobs:
         id: testspace_tool
         uses: testspace-com/setup-testspace@v1 
         with: 
-          domain: ${{ github.repository_owner }} 
+          domain: ${{ github.repository_owner }}
+          token: ${{ secrets.TESTSPACE_TOKEN }}
 
       - if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         name: Bump release version and create release tag

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,8 @@ jobs:
         with: 
           fetch-depth: 50 
 
-      - name: Activate TestSpace tool
+      - if: github.repository_owner == github.actor
+        name: Activate TestSpace tool
         id: testspace_tool
         uses: testspace-com/setup-testspace@v1 
         with: 
@@ -93,11 +94,11 @@ jobs:
         id: run_project_tests
         run: dotnet fake run Source\Builder\build.fsx target test
 
-      - name: Push result to Testspace server 
+      - if: github.repository_owner == github.actor && always()
+        name: Push result to Testspace server 
         id: push_to_testspace
         run: | 
           testspace __test/results.xml  
-        if: always() 
 
       - if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         name: Upload package artifact


### PR DESCRIPTION
Add a token requirement to the TestSpace initialization.
Add the same condition as on SonarCloud, to prevent PR fork-to-upstream from activating TestSpace